### PR TITLE
add Hex version to the list of alternate Pong Wars versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ The alternate versions are listed below in alphabetical order:
 - [Yin-Yang Pong](https://ying-yang-pong.vercel.app/)
 - [Ying Yang](https://twitter.com/a__islam/status/1751485227787034863)
 - [M5Stack version](https://github.com/anoken/pong-wars-forM5Stack/)
+- [Hex version](https://pong-wars-hex.whichoneiwonder.com/)


### PR DESCRIPTION
Hey there, I know you first created this months ago but it was a really fun project to convert to a hex-grid 😄 

Hex version has been deployed [Here](https://hex-pong-wars.whichoneiwonder.com)

![hero3](https://github.com/user-attachments/assets/8ec5d175-4c15-4029-b7bd-56234ef58b70)

I'm keen to be added to your list but no dramas if you're not updating it anymore



The change adds a new version of the project to the list of alternate versions.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68): Added the "Hex version" to the list of alternate versions.