### PR TITLE
Add ThunderPong to alternate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The alternate versions are listed below in alphabetical order:
 - [SwiftUI (Native)](https://github.com/1998code/pong-wars-swiftui)
 - [Swift (SpriteKit)](https://github.com/frederik-jacques/ios-pongwars)
 - [Tag-Team](https://github.com/SSteve/pong-wars) ([Live](https://ssteve.github.io/pong-wars/))
+- [ThunderPong (paddles, wind, power-ups, online multiplayer)](https://3210.lu/thunderpong/) ([Multiplayer](https://3210.lu/thunderpong/mp/))
 - [Yin-Yang Pong](https://ying-yang-pong.vercel.app/)
 - [Ying Yang](https://twitter.com/a__islam/status/1751485227787034863)
 - [M5Stack version](https://github.com/anoken/pong-wars-forM5Stack/)


### PR DESCRIPTION
Adding a paddle-based alternate version to the list, as invited in the README.

**ThunderPong** — https://3210.lu/thunderpong/ (multiplayer: https://3210.lu/thunderpong/mp/)

The day/night territory idea, but each side keeps its own ball alive with a paddle, so it becomes a game rather than a simulation:

- each paddle only ever touches its own ball, so there are no disputed collisions
- a shared, visible wind curves both flights without changing their speed
- bonus bricks (blast / bolt / slow) spawn as mirrored pairs, never randomly
- swinging the paddle at the moment of contact adds spin and energy
- plays on desktop and touch, single player against a bot or online against a stranger

Placed alphabetically between Tag-Team and Yin-Yang Pong, in the same two-link format the Tag-Team entry uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)